### PR TITLE
force wp_list_comments default,err: bubble+ cmt at bottom

### DIFF
--- a/frontend/class-comments.php
+++ b/frontend/class-comments.php
@@ -107,7 +107,7 @@ class INCOM_Comments extends INCOM_Frontend {
 			'callback' => array( $this, 'loadComment' ),
 			'avatar_size' => parent::get_avatar_size(),
 		);
-		wp_list_comments( apply_filters( 'incom_comments_list_args', $args ), get_comments() );
+		wp_list_comments( apply_filters( 'incom_comments_list_args', $args ), get_comments($args) );
 	}
 
 	/**

--- a/frontend/class-comments.php
+++ b/frontend/class-comments.php
@@ -107,7 +107,7 @@ class INCOM_Comments extends INCOM_Frontend {
 			'callback' => array( $this, 'loadComment' ),
 			'avatar_size' => parent::get_avatar_size(),
 		);
-		wp_list_comments( apply_filters( 'incom_comments_list_args', $args ) );
+		wp_list_comments( apply_filters( 'incom_comments_list_args', $args ), get_comments() );
 	}
 
 	/**


### PR DESCRIPTION
In my current version 4.4.2 wp_list_comments does not handle so well this $comment default parameter, and relies too much on query ; 

Symptoms result is that the comments appear at the bottom and bubbles contain always plus.

Sorry for the cosmetic return at the last line.
